### PR TITLE
Add explicit installation instructions for Textmate 1.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -2,6 +2,12 @@
 
 You can install this bundle in TextMate by opening the preferences and going to the bundles tab. After installation it will be automatically updated for you.
 
+Installation for TextMate 1:
+
+    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
+    cd ~/Library/Application\ Support/TextMate/Bundles
+    git clone git://github.com/textmate/json.tmbundle
+
 # General
 
 * [Bundle Styleguide](http://kb.textmate.org/bundle_styleguide) — _before you make changes_


### PR DESCRIPTION
Not sure if it is a Textmate 2 thing or not but there is no bundles tab on preferences so installing this bundle required cloning the repo into the bundles directory. 

This should help people get it installed quickly.
