### PR TITLE
Add JSON key scope as string.quoted.double.key.json

### DIFF
--- a/Syntaxes/JSON.tmLanguage
+++ b/Syntaxes/JSON.tmLanguage
@@ -129,8 +129,51 @@
 				<dict>
 					<key>comment</key>
 					<string>the JSON object key</string>
-					<key>include</key>
-					<string>#string</string>
+					<key>begin</key>
+					<string>"</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.begin.json</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>"</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.end.json</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>string.quoted.double.key.json</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?x:                # turn on extended mode
+                             \\                # a literal backslash
+                             (?:               # ...followed by...
+                               ["\\/bfnrt]     # one of these characters
+                               |               # ...or...
+                               u               # a u
+                               [0-9a-fA-F]{4}  # and four hex digits
+                             )
+                           )</string>
+							<key>name</key>
+							<string>constant.character.escape.json</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\.</string>
+							<key>name</key>
+							<string>invalid.illegal.unrecognized-string-escape.json</string>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
Right now, specifying JSON keys for syntax highlighting requires a [nasty hack](https://github.com/MattDMo/Neon-color-scheme/blob/master/Neon.tmTheme#L1139). I noticed [another PR](https://github.com/textmate/json.tmbundle/pull/2) which was declined, so I thought I'd give it a try.

I basically grabbed the entire `string` rule and c+ped it in place of the include, with the appropriate name based on the string scope, `string.quoted.double.key.json`. The c+p seemed clumsy to me, but I couldn't find any other way to do it. (I tried taking the name out of the `string` rule, and then specifying it at each of the points where it was included, but that didn't seem to work.) Let me know what you think.
