### PR TITLE
Add Reformat Document / Selection without encoding

### DIFF
--- a/Commands/Reformat Document : Selection without encoding.tmCommand
+++ b/Commands/Reformat Document : Selection without encoding.tmCommand
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/usr/bin/env ruby
+require 'json'
+
+stdin = STDIN.read
+begin
+hash = JSON.parse stdin
+print JSON.pretty_generate(hash, indent: " "*4)
+rescue Exception =&gt; e
+print stdin
+end</string>
+	<key>input</key>
+	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>^H</string>
+	<key>name</key>
+	<string>Reformat Document / Selection without encoding</string>
+	<key>outputCaret</key>
+	<string>heuristic</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>replaceInput</string>
+	<key>scope</key>
+	<string>source.json</string>
+	<key>version</key>
+	<integer>2</integer>
+	<key>uuid</key>
+	<string>9575D84D-29B3-4213-ADB0-E0D1FD39B407</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -13,6 +13,7 @@
 		<key>items</key>
 		<array>
 			<string>4B74F2DE-E051-4E8D-9124-EBD90A2CDD2B</string>
+			<string>9575D84D-29B3-4213-ADB0-E0D1FD39B407</string>
 			<string>CB0DD80E-CD51-49C3-A89C-57E8C3168067</string>
 		</array>
 	</dict>


### PR DESCRIPTION
enhanced "Reformat Document / Selection" like below

source.json

```json
{
    "hello": {
        "en": "Hello World!",
        "ru": "привет мир!",
        "ja": "こんにちは　世界！"
    }
}
```

Reformat Document / Selection

```json
{
    "hello": {
        "en": "Hello World!",
        "ja": "\u3053\u3093\u306b\u3061\u306f\u3000\u4e16\u754c\uff01",
        "ru": "\u043f\u0440\u0438\u0432\u0435\u0442 \u043c\u0438\u0440!"
    }
}
```

Reformat Document / Selectionwithout encoding( this PR )

```json
{
    "hello": {
        "en": "Hello World!",
        "ru": "привет мир!",
        "ja": "こんにちは　世界！"
    }
}
```