### PR TITLE
add comma as TM_LINE_TERMINATOR

### DIFF
--- a/Preferences/Miscellaneous.tmPreferences
+++ b/Preferences/Miscellaneous.tmPreferences
@@ -31,6 +31,15 @@
 				<string>]</string>
 			</array>
 		</array>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_LINE_TERMINATOR</string>
+				<key>value</key>
+				<string>,</string>
+			</dict>
+		</array>
 	</dict>
 	<key>uuid</key>
 	<string>9D83F5F7-ECAD-4EFE-ADAC-2063C7EFED56</string>


### PR DESCRIPTION
add comma as the line terminator for JSON, thus enabling <kbd>⇧</kbd><kbd>⌘</kbd><kbd>↩</kbd> `Move to EOL and Insert Terminator + LF` convenience to editing JSON documents.