### PR TITLE
Use Native Ruby

### DIFF
--- a/Commands/Reformat Document : Selection.tmCommand
+++ b/Commands/Reformat Document : Selection.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby20
+	<string>#!/usr/bin/env ruby
 require 'json'
 
 stdin = STDIN.read


### PR DESCRIPTION
`ruby20` was an old Homebrew-installed version for getting Ruby 2 on old macOS (see https://stackoverflow.com/a/14138490). This fix simply uses system installed Ruby, which ensures macOS compatibility on supported versions since 10.9

For reference, this is one of *many* uses throughout the TM Bundle codebase, which guarantee that the affected Bundle Commands will not run on any version of vanilla macOS: https://github.com/search?q=org%3Atextmate+ruby20&type=Code