### PR TITLE
Fix Validate Syntax JSON bundle command for Mac OS 12.3+

### DIFF
--- a/Commands/Validate Syntax.tmCommand
+++ b/Commands/Validate Syntax.tmCommand
@@ -8,7 +8,7 @@
 	<string>#!/usr/bin/env ruby18
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
 
-error = `cat | python -mjson.tool 2&gt;&amp;1 &gt; /dev/null`
+error = `cat | python3 -mjson.tool 2&gt;&amp;1 &gt; /dev/null`
 
 if error.empty?
   puts "Valid JSON, no errors"


### PR DESCRIPTION
python2 is extremely deprecated and no longer ships on Monterey. Homebrew also no longer offers it as a package. Update the Validate Syntax JSON bundle command to use python3 instead of python2.